### PR TITLE
Escape keys in case one is a reserved word

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,12 +8,16 @@ module.exports = function( data ) {
 
     data = JSON.parse( data );
 
-    function getSCSS( chunk ) {
+    function getSCSS( chunk, initial ) {
         var scss = '';
 
         if ( typeof chunk === "object" && ! Array.isArray( chunk ) ) {
             _.mapKeys(chunk, function(value, key) {
-                scss += key + ': '
+                if (initial) {
+                    scss += key + ': '
+                } else {
+                    scss += "'" + key + "': "
+                }
 
                 if (typeof value === "object") {
                     if ( Array.isArray( value ) ) {
@@ -46,5 +50,5 @@ module.exports = function( data ) {
         return scss;
     }
 
-    return '$' + getSCSS( data ) + ';';
+    return '$' + getSCSS( data, true ) + ';';
 }


### PR DESCRIPTION
If I have a JSON like this:
```json
{
	"colors": {
		"yellow": "#ffff00"
	}
}
```
it outputs
```scss
$colors: (yellow: #ffff00);
```

But I can't access it because `yellow` isn't considered a string but a color.

So I changed the generation to 
```scss
$colors: ('yellow': #ffff00);
```

so I can access it.

*(Tested with DartSass 1.6.2)*